### PR TITLE
[MARKUP] AuthInput 컴포넌트 퍼블리싱 #11

### DIFF
--- a/src/app/(start-view)/layout.tsx
+++ b/src/app/(start-view)/layout.tsx
@@ -15,7 +15,7 @@ export default function Layout({
                 height={250} 
                 alt="Logo"
             />
-            <div className='bg-white w-full rounded-lg p-6'>
+            <div className='bg-white w-full rounded-lg px-6 py-12'>
                 {children}
             </div>
         </div>

--- a/src/app/(start-view)/page.tsx
+++ b/src/app/(start-view)/page.tsx
@@ -1,7 +1,23 @@
+import AuthInput from "@/components/user/AuthInput"
+
 export default function Page() {
   return (
-    <h1 className="text-3xl font-bold">
-      로그인 영역
-    </h1>
+    <div className="flex flex-col justify-start gap-7">
+      <h1 className="text-xl font-bold text-center">
+        안녕하세요 !
+      </h1>
+      <AuthInput
+        label="이메일"
+        type="text"
+        required
+        placeholder="이메일을 입력하세요"
+        rightAddon
+      />
+      <AuthInput
+        label="비밀번호"
+        type="password"
+        placeholder="비밀번호를 입력하세요"
+      />
+    </div>
   )
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,7 +1,7 @@
 /* globals.css */
 @import "tailwindcss";
 
-/* 커스텀 색상 변수 설정 */
+/* 커스텀 변수 설정 */
 :root {
   /* Colors */
   --color-main: #0EB77F;
@@ -19,6 +19,9 @@
   /* Spacing */
   --spacing-section: 48px;
   --vh: 100%;
+
+  /* Border */
+  --border-thin: 1px;
 }
 
 html {
@@ -47,6 +50,20 @@ body {
   font-family: "Pretendard";
   src: url("/fonts/Pretendard-Regular.woff2") format("woff2");
   font-weight: 400;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: "Pretendard";
+  src: url("/fonts/Pretendard-Medium.woff2") format("woff2");
+  font-weight: 500;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: "Pretendard";
+  src: url("/fonts/Pretendard-SemiBold.woff2") format("woff2");
+  font-weight: 600;
   font-style: normal;
 }
 

--- a/src/components/user/AuthInput.tsx
+++ b/src/components/user/AuthInput.tsx
@@ -1,0 +1,48 @@
+import DuplicateButton from "./DuplicateButton";
+
+interface AuthInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+    label: string;
+    required?: boolean;
+    type: string;
+    rightAddon?: boolean; // 중복 버튼
+}
+
+export default function AuthInput({
+    label,
+    required = false,
+    rightAddon = false,
+    className,
+    ...props
+}: AuthInputProps) {
+
+    function onDuplicateCheck(): void {
+        throw new Error("Function not implemented.");
+    }
+
+    return (
+        <div className="flex flex-col items-start justify-start gap-1">
+            <label className="text-sm font-medium flex items-center gap-1">
+                {label}
+                {required && <span className="text-red-500">*</span>}
+                {/* {rightAddon && <span className="ml-1">{rightAddon}</span>} */}
+            </label>
+            <div className="relative w-full">
+                <input
+                    {...props}
+                    className={
+                        "w-full p-3 border border-gray-100 rounded-lg text-sm font-medium focus:outline-(--color-main) placeholder:text-gray-300 placeholder:font-medium"
+                    }
+                />
+                {rightAddon && (
+                    <div className="absolute right-2 top-1/2 -translate-y-1/2">
+                        <DuplicateButton
+                            onClick={function (): void {
+                                throw new Error("Function not implemented.");
+                            }}
+                        />
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/src/components/user/DuplicateButton.tsx
+++ b/src/components/user/DuplicateButton.tsx
@@ -1,0 +1,18 @@
+interface DuplicateButtonProps {
+    onClick: () => void;
+    disabled?: boolean;
+    label?: string;
+}
+
+export default function DuplicateButton({ onClick, disabled = false, label = "중복" }: DuplicateButtonProps) {
+    return (
+        <button
+            type="button"
+            //onClick={onClick}
+            disabled={disabled}
+            className="text-xs font-medium px-3.5 py-2 rounded-md bg-(--color-navActive) text-white disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+            {label}
+        </button>
+    );
+}


### PR DESCRIPTION
## 📌 연관된 이슈

#11

## ✅ 작업 내용

이메일, 닉네임, 비밀번호와 같은 사용자 정보 입력칸인 AuthInput 컴포넌트를 퍼블리싱하였습니다.
추가적으로 중복확인이 필요한 경우가 있어 중복확인 버튼인 DuplicateButton 컴포넌트 또한 퍼블리싱하였습니다.


## 📷 스크린샷 (선택)

<img width="479" height="232" alt="스크린샷 2025-11-26 141641" src="https://github.com/user-attachments/assets/4e313b2e-345c-4f55-821d-7211dbd9e23b" />

