### PR TITLE
[MARKUP] 로그인 페이지 UI 퍼블리싱 #13

### DIFF
--- a/src/app/(start-view)/layout.tsx
+++ b/src/app/(start-view)/layout.tsx
@@ -11,8 +11,8 @@ export default function Layout({
         <div className='flex flex-col items-center justify-center h-screen bg-(--color-main) gap-10 px-9'>
             <Image
                 src={logoImage}
-                width={250}
-                height={250} 
+                width={200}
+                height={200} 
                 alt="Logo"
             />
             <div className='bg-white w-full rounded-lg px-6 py-12'>

--- a/src/app/(start-view)/page.tsx
+++ b/src/app/(start-view)/page.tsx
@@ -2,6 +2,7 @@
 
 import AuthInput from "@/components/user/AuthInput"
 import PrimaryButton from "@/components/common/PrimaryButton"
+import LinkButton from "@/components/user/LinkButton";
 import { useState } from "react";
 
 export default function Page() {
@@ -37,7 +38,12 @@ export default function Page() {
           onChange={(e) => setPassword(e.target.value)}
         />
 
-        <div className="flex justify-center mt-3">
+        <div className="flex justify-evenly">
+          <LinkButton href="/guest_laguage_select" label="비회원으로 즐기기" />
+          <LinkButton href="/signup" label="아직 회원이 아니신가요?" />
+        </div>
+
+        <div className="flex justify-center mt-2">
           <PrimaryButton
             label="로그인"
             onClick={handleSubmit}

--- a/src/components/LinkButton.tsx/AuthInput.tsx
+++ b/src/components/LinkButton.tsx/AuthInput.tsx
@@ -1,0 +1,48 @@
+import DuplicateButton from "./DuplicateButton";
+
+interface AuthInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+    label: string;
+    required?: boolean;
+    type: string;
+    rightAddon?: boolean; // 중복 버튼
+}
+
+export default function AuthInput({
+    label,
+    required = false,
+    rightAddon = false,
+    className,
+    ...props
+}: AuthInputProps) {
+
+    function onDuplicateCheck(): void {
+        throw new Error("Function not implemented.");
+    }
+
+    return (
+        <div className="flex flex-col items-start justify-start gap-1">
+            <label className="text-sm font-medium flex items-center gap-1">
+                {label}
+                {required && <span className="text-red-500">*</span>}
+                {/* {rightAddon && <span className="ml-1">{rightAddon}</span>} */}
+            </label>
+            <div className="relative w-full">
+                <input
+                    {...props}
+                    className={
+                        "w-full p-3 border border-gray-100 rounded-lg text-sm font-medium focus:outline-(--color-main) placeholder:text-gray-300 placeholder:font-medium"
+                    }
+                />
+                {rightAddon && (
+                    <div className="absolute right-2 top-1/2 -translate-y-1/2">
+                        <DuplicateButton
+                            onClick={function (): void {
+                                throw new Error("Function not implemented.");
+                            }}
+                        />
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/src/components/user/LinkButton.tsx
+++ b/src/components/user/LinkButton.tsx
@@ -1,0 +1,17 @@
+import Link from "next/link";
+
+interface LinkButtonProps {
+  href: string;
+  label: string;
+}
+
+export default function LinkButton({ href, label }: LinkButtonProps) {
+  return (
+    <Link
+      href={href}
+      className="text-gray-400 text-xs font-medium p-1 rounded-md active:bg-gray-200 transition-all duration-150"
+    >
+      {label}
+    </Link>
+  );
+}


### PR DESCRIPTION
## 📌 연관된 이슈

#13

## ✅ 작업 내용

로그인 화면 UI를 구성하였습니다.
LinkButton 컴포넌트를 생성하여 비회원 언어선택 페이지와 회원가입 페이지로 링크 이동 설정을 해두었습니다.


## 📷 스크린샷 (선택)

<img width="624" height="898" alt="스크린샷 2025-11-26 152938" src="https://github.com/user-attachments/assets/937f991a-379d-4ad1-a7c2-fa8b6f838614" />
