### PR TITLE
[MARKUP] 사용자 페이지에서 사용하는 ModalContent 컴포넌트 퍼블리싱 #32

### DIFF
--- a/src/app/(with-nav)/user/page.tsx
+++ b/src/app/(with-nav)/user/page.tsx
@@ -7,10 +7,15 @@ import UserSettingList from "@/components/user/UserSettingList";
 import { useRouter } from 'next/navigation';
 import { useState } from "react";
 import Modal from "@/components/common/Modal";
+import UpdatePasswordModal from "@/components/user/modal/UpdatePasswordModal";
+import AccountDeleteModal from "@/components/user/modal/AccountDeleteModal";
+import LogoutConfirmModal from "@/components/user/modal/LogoutConfirmModal";
 
 export default function Page() {
   const router = useRouter();
-  const [showModal, setShowModal] = useState(false);
+  const [showUpdatePasswordModal, setShowUpdatePasswordModal] = useState(false);
+  const [showAccountDeleteModal, setShowAccountDeleteModal] = useState(false);
+  const [showLogoutConfirmModal, setShowLogoutConfirmModal] = useState(false);
 
   function handleSubmit(e?: React.FormEvent) {
     if (e) e.preventDefault();
@@ -45,11 +50,11 @@ export default function Page() {
         />
         <UserSettingList
           label={"비밀번호 변경"}
-          onClick={() => setShowModal(true)}
+          onClick={() => setShowUpdatePasswordModal(true)}
         />
         <UserSettingList
           label={"계정탈퇴"}
-          onClick={() => router.push("/user")}
+          onClick={() => setShowAccountDeleteModal(true)}
         />
       </div>
 
@@ -57,20 +62,40 @@ export default function Page() {
       <div className="flex justify-center mt-2">
         <PrimaryButton
           label="로그아웃"
-          onClick={handleSubmit}
+          onClick={() => setShowLogoutConfirmModal(true)}
         />
       </div>
 
-      {/* 모달 표시 */}
-      {showModal && (
+      {/* 비밀번호 변경 모달 표시 */}
+      {showUpdatePasswordModal && (
         <Modal
           title="비밀번호 변경"
-          buttonLabel="저장"
-          onClose={() => setShowModal(false)}
+          buttonLabel="변경"
+          onClose={() => setShowUpdatePasswordModal(false)}
         >
-          <div className="flex flex-col justify-start items-center my-3 bg-amber-200">
-            콘텐츠 영역
-          </div>
+          <UpdatePasswordModal />
+        </Modal>
+      )}
+
+      {/* 계정탈퇴 모달 표시 */}
+      {showAccountDeleteModal && (
+        <Modal
+          title="계정탈퇴"
+          buttonLabel="탈퇴"
+          onClose={() => setShowAccountDeleteModal(false)}
+        >
+          <AccountDeleteModal />
+        </Modal>
+      )}
+
+      {/* 로그아웃 모달 표시 */}
+      {showLogoutConfirmModal && (
+        <Modal
+          title="로그아웃"
+          buttonLabel="로그아웃"
+          onClose={() => setShowLogoutConfirmModal(false)}
+        >
+          <LogoutConfirmModal />
         </Modal>
       )}
     </div>

--- a/src/components/user/AuthInput.tsx
+++ b/src/components/user/AuthInput.tsx
@@ -1,16 +1,18 @@
-import DuplicateButton from "./DuplicateButton";
+import InputCheckButton from "./InputCheckButton";
 
 interface AuthInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
     label: string;
     required?: boolean;
     type: string;
     rightAddon?: boolean; // 중복 버튼
+    passWordCheck?: boolean; //비밀번호 확인 버튼
 }
 
 export default function AuthInput({
     label,
     required = false,
     rightAddon = false,
+    passWordCheck = false,
     className,
     ...props
 }: AuthInputProps) {
@@ -35,10 +37,21 @@ export default function AuthInput({
                 />
                 {rightAddon && (
                     <div className="absolute right-2 top-1/2 -translate-y-1/2">
-                        <DuplicateButton
+                        <InputCheckButton
                             onClick={function (): void {
                                 throw new Error("Function not implemented.");
                             }}
+                        />
+                    </div>
+                )}
+
+                {passWordCheck && (
+                    <div className="absolute right-2 top-1/2 -translate-y-1/2">
+                        <InputCheckButton
+                            onClick={function (): void {
+                                throw new Error("Function not implemented.");
+                            }}
+                            label="확인"
                         />
                     </div>
                 )}

--- a/src/components/user/InputCheckButton.tsx
+++ b/src/components/user/InputCheckButton.tsx
@@ -1,10 +1,10 @@
-interface DuplicateButtonProps {
+interface InputCheckButtonProps {
     onClick: () => void;
     disabled?: boolean;
     label?: string;
 }
 
-export default function DuplicateButton({ onClick, disabled = false, label = "중복" }: DuplicateButtonProps) {
+export default function InputCheckButton({ onClick, disabled = false, label = "중복" }: InputCheckButtonProps) {
     return (
         <button
             type="button"

--- a/src/components/user/modal/AccountDeleteModal.tsx
+++ b/src/components/user/modal/AccountDeleteModal.tsx
@@ -1,0 +1,16 @@
+import AuthInput from "../AuthInput";
+
+export default function AccountDeleteModal() {
+    return (
+        <div className="flex flex-col gap-5">
+            <p className="text-gray-500 text-sm text-center leading-relaxed">
+                계정을 삭제하면 모든 정보가 사라집니다. <br />
+                삭제를 원하신다면 비밀번호를 입력해주세요.
+            </p>
+            <AuthInput
+                label={"현재 비밀번호 확인"}
+                type={"password"}
+            />
+        </div>
+    );
+}

--- a/src/components/user/modal/LogoutConfirmModal.tsx
+++ b/src/components/user/modal/LogoutConfirmModal.tsx
@@ -1,0 +1,7 @@
+export default function LogoutConfirmModal() {
+    return (
+        <p className="text-gray-500 text-sm text-center leading-relaxed">
+            로그아웃 하시겠습니까?
+        </p>
+    );
+}

--- a/src/components/user/modal/UpdatePasswordModal.tsx
+++ b/src/components/user/modal/UpdatePasswordModal.tsx
@@ -1,0 +1,21 @@
+import AuthInput from "../AuthInput";
+
+export default function UpdatePasswordModal() {
+    return (
+        <div className="flex flex-col gap-5 my-5">
+            <AuthInput
+                label={"현재 비밀번호 확인"}
+                type={"password"}
+                passWordCheck
+            />
+            <AuthInput
+                label={"새 비밀번호"}
+                type={"password"}
+            />
+            <AuthInput
+                label={"새 비밀번호 확인"}
+                type={"password"}
+            />
+        </div>
+    );
+}


### PR DESCRIPTION
## 📌 연관된 이슈

#32

## ✅ 작업 내용

비밀번호 변경 모달 컴포넌트(UpdatePasswordModal)를 퍼블리싱 했습니다.
계정 탈퇴 모달 컴포넌트(AccountDeleteModal)를 퍼블리싱 했습니다.
로그아웃 모달 컴포넌트(LogoutConfirmModal)를 퍼블리싱 했습니다.


## 📷 스크린샷 (선택)

<img width="364" height="437" alt="스크린샷 2025-11-27 182146" src="https://github.com/user-attachments/assets/736de5b6-a1c7-4a48-a935-53c1ce2451c0" />
<img width="375" height="292" alt="스크린샷 2025-11-27 182154" src="https://github.com/user-attachments/assets/d2cb82ab-8db8-4cfa-a2ef-bb0f2f438168" />
<img width="362" height="197" alt="스크린샷 2025-11-27 182202" src="https://github.com/user-attachments/assets/143dd76f-8787-413f-b066-829b65b9e46a" />
