### PR TITLE
[MARKUP] 좋아요 리스트 조회 페이지 UI 퍼블리싱 #50

### DIFF
--- a/src/app/(with-header)/layout.tsx
+++ b/src/app/(with-header)/layout.tsx
@@ -1,26 +1,3 @@
-import '../globals.css';
-import { ArrowLeft } from 'lucide-react';
-
-export default function Layout({
-    children,
-}: Readonly<{
-    children: React.ReactNode;
-}>) {
-    return (
-        <div className='flex flex-col justify-start gap-4 h-screen'>
-            {/* 상단 헤더 영역 */}
-            {/* 상단 헤더 */}
-            <div className="relative p-5 flex items-center">
-                {/* 좌측 뒤로가기 버튼 */}
-                <button>
-                    <ArrowLeft className="z-10" />
-                </button>
-                {/* 가운데 제목 */}
-                <p className="absolute left-1/2 -translate-x-1/2 text-xl font-semibold">
-                    헤더 제목
-                </p>
-            </div>
-            {children}
-        </div>
-    );
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
 }

--- a/src/app/(with-header)/user/likes/page.tsx
+++ b/src/app/(with-header)/user/likes/page.tsx
@@ -1,3 +1,4 @@
+import HeaderLayout from "@/components/common/HeaderLayout";
 import SearchBar from "@/components/common/SearchBar";
 import TagSelectSection from "@/components/common/TagSelectSection";
 import UserCourseList from "@/components/user/UserCourseList";
@@ -5,22 +6,24 @@ import userLikedCourseList from "@/mock/userLikedCourseList.json"
 
 export default function Page() {
   return (
-    <div className="flex flex-col h-full px-10 justify-start items-center gap-5">
-      <SearchBar />
-      <TagSelectSection/>
-      <div className="w-full flex flex-col gap-3 mt-5">
-        {userLikedCourseList.map((course) => (
-        <UserCourseList
-          key={course.courseId}
-          courseId={course.courseId}
-          title={course.title}
-          writer={course.writer}
-          tag={course.tag}
-          liked={course.liked}
-          likeNum={course.likeNum}
-        />
-      ))}
+    <HeaderLayout title={"내가 좋아요 한 코스"}>
+      <div className="flex flex-col h-full px-10 pb-10 justify-start items-center gap-5">
+        <SearchBar />
+        <TagSelectSection />
+        <div className="w-full flex flex-col gap-3">
+          {userLikedCourseList.map((course) => (
+            <UserCourseList
+              key={course.courseId}
+              courseId={course.courseId}
+              title={course.title}
+              writer={course.writer}
+              tag={course.tag}
+              liked={course.liked}
+              likeNum={course.likeNum}
+            />
+          ))}
+        </div>
       </div>
-    </div>
+    </HeaderLayout>
   )
 }

--- a/src/components/common/HeaderLayout.tsx
+++ b/src/components/common/HeaderLayout.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { ArrowLeft } from "lucide-react";
+import { useRouter } from "next/navigation";
+
+interface HeaderLayoutProps {
+    title: string;
+    children: React.ReactNode;
+}
+
+export default function HeaderLayout({ title, children }: HeaderLayoutProps) {
+    const router = useRouter();
+
+    return (
+        <div className='flex flex-col justify-start h-full'>
+            {/* 상단 헤더 영역 */}
+            {/* 상단 헤더 */}
+            <div className="relative p-5 flex items-center">
+                {/* 좌측 뒤로가기 버튼 */}
+                <button
+                    onClick={() => router.back()}
+                >
+                    <ArrowLeft className="z-10" />
+                </button>
+                {/* 가운데 제목 */}
+                <p className="absolute left-1/2 -translate-x-1/2 text-xl font-semibold">
+                    {title}
+                </p>
+            </div>
+            
+            {children}
+        </div>
+    );
+}

--- a/src/components/user/UserCourseList.tsx
+++ b/src/components/user/UserCourseList.tsx
@@ -18,7 +18,7 @@ export default function UserCourseList({ courseId, thumbnail, title, writer, tag
     const displayThumbnail = thumbnail || "/img/OlCo_logo_3.png";
 
     return (
-        <Link href={`/courses/${courseId}`} className="flex w-full h-gap-3">
+        <Link href={`/courses/${courseId}`} className="flex w-full gap-2">
             {/* 썸네일 이미지 영역 */}
             <div className="relative w-28 aspect-4/3 border border-[#E1E1E1] rounded-lg overflow-hidden shrink-0 bg-gray-100">
                 <Image

--- a/src/mock/userLikedCourseList.json
+++ b/src/mock/userLikedCourseList.json
@@ -18,6 +18,33 @@
         "liked": false
     },
     {
+        "courseId": 32,
+        "thumbnail": "",
+        "title": "벚꽃 나들이🌸",
+        "writer": "듀?",
+        "tag" : ["혼자", "뚜벅이", "추움"],
+        "likeNum": 124,
+        "liked": false
+    },
+    {
+        "courseId": 32,
+        "thumbnail": "",
+        "title": "벚꽃 나들이🌸",
+        "writer": "듀?",
+        "tag" : ["혼자", "뚜벅이", "추움"],
+        "likeNum": 124,
+        "liked": false
+    },
+    {
+        "courseId": 32,
+        "thumbnail": "",
+        "title": "벚꽃 나들이🌸",
+        "writer": "듀?",
+        "tag" : ["혼자", "뚜벅이", "추움"],
+        "likeNum": 124,
+        "liked": false
+    },
+    {
         "courseId": 42,
         "thumbnail": "",
         "title": "콘서트 제대로 뿌시는 코스 콘서트 제대로 뿌시는 코스 콘서트 제대로 뿌시는 코스",


### PR DESCRIPTION
## 📌 연관된 이슈

#50

## ✅ 작업 내용

- 좋아요 리스트 조회 페이지의 UI를 퍼블리싱 하였습니다.
- (with-header) 하단 페이지의 layout.tsx는 props를 받을 수 없어 따로 HeaderLayout 컴포넌트를 생성하였습니다.
- HeaderLayout의 props로 title을 받아와 각 페이지의 타이틀이 출력되도록 하였습니다.


## 📷 스크린샷 (선택)

<img width="631" height="897" alt="스크린샷 2025-11-28 195143" src="https://github.com/user-attachments/assets/287f60fa-1988-4438-985a-187634391351" />
