### PR TITLE
[MARKUP] 작성 글 리스트 조회 페이지 UI 퍼블리싱 #45

### DIFF
--- a/src/app/(with-header)/user/likes/page.tsx
+++ b/src/app/(with-header)/user/likes/page.tsx
@@ -15,6 +15,7 @@ export default function Page() {
             <UserCourseList
               key={course.courseId}
               courseId={course.courseId}
+              thumbnail={course.thumbnail}
               title={course.title}
               writer={course.writer}
               tag={course.tag}

--- a/src/app/(with-header)/user/posts/page.tsx
+++ b/src/app/(with-header)/user/posts/page.tsx
@@ -1,7 +1,30 @@
+import HeaderLayout from "@/components/common/HeaderLayout";
+import SearchBar from "@/components/common/SearchBar";
+import TagSelectSection from "@/components/common/TagSelectSection";
+import UserCourseList from "@/components/user/UserCourseList";
+import userPostedCourseList from "@/mock/userPostedCourseList.json"
+
 export default function Page() {
   return (
-    <h1 className="text-3xl font-bold">
-      사용자 작성 코스 리스트
-    </h1>
+    <HeaderLayout title={"작성 글 리스트"}>
+      <div className="flex flex-col h-full px-10 pb-10 justify-start items-center gap-5">
+        <SearchBar />
+        <TagSelectSection />
+        <div className="w-full flex flex-col gap-3">
+          {userPostedCourseList.map((course) => (
+            <UserCourseList
+              key={course.courseId}
+              courseId={course.courseId}
+              thumbnail={course.thumbnail}
+              title={course.title}
+              writer={course.writer}
+              tag={course.tag}
+              liked={course.liked}
+              likeNum={course.likeNum}
+            />
+          ))}
+        </div>
+      </div>
+    </HeaderLayout>
   )
 }

--- a/src/components/user/UserCourseList.tsx
+++ b/src/components/user/UserCourseList.tsx
@@ -15,7 +15,8 @@ interface UserCourseListProps {
 
 export default function UserCourseList({ courseId, thumbnail, title, writer, tag, liked, likeNum }: UserCourseListProps) {
 
-    const displayThumbnail = thumbnail || "/img/OlCo_logo_3.png";
+    const displayThumbnail =
+        thumbnail && thumbnail.trim() !== "" ? thumbnail : "/img/OlCo_logo_3.png";
 
     return (
         <Link href={`/courses/${courseId}`} className="flex w-full gap-2">

--- a/src/mock/userPostedCourseList.json
+++ b/src/mock/userPostedCourseList.json
@@ -1,0 +1,66 @@
+[
+    {
+        "courseId": 1,
+        "thumbnail": "",
+        "title": "연인과 함께 즐기는 데이트 코스",
+        "writer": "듀?",
+        "tag": [
+            "연인과",
+            "따뜻함"
+        ],
+        "likeNum": 259,
+        "liked": true
+    },
+    {
+        "courseId": 2,
+        "thumbnail": "",
+        "title": "콘서트에서 써먹을 좋은 코스를 소개합니다",
+        "writer": "듀?",
+        "tag": [
+            "혼자",
+            "뚜벅이",
+            "추움"
+        ],
+        "likeNum": 259,
+        "liked": true
+    },
+    {
+        "courseId": 3,
+        "thumbnail": "",
+        "title": "지쳤나요? 네🚨🚨🚨",
+        "writer": "듀?",
+        "tag": [
+            "혼자",
+            "뚜벅이",
+            "추움"
+        ],
+        "likeNum": 259,
+        "liked": true
+    },
+    {
+        "courseId": 4,
+        "thumbnail": "",
+        "title": "가나디와 함께하는 산책 코스",
+        "writer": "듀?",
+        "tag": [
+            "반려동물",
+            "뚜벅이",
+            "추움"
+        ],
+        "likeNum": 259,
+        "liked": true
+    },
+    {
+        "courseId": 5,
+        "thumbnail": "",
+        "title": "쓸쓸한 가을날을 즐기는 코스",
+        "writer": "듀?",
+        "tag": [
+            "혼자",
+            "뚜벅이",
+            "추움"
+        ],
+        "likeNum": 259,
+        "liked": true
+    }
+]


### PR DESCRIPTION
## 📌 연관된 이슈

#45

## ✅ 작업 내용

- 작성 글 리스트 조회 페이지의 UI를 퍼블리싱 하였습니다.


## 📷 스크린샷 (선택)

<img width="617" height="900" alt="스크린샷 2025-11-28 202508" src="https://github.com/user-attachments/assets/b2d4d7a9-a902-4edf-814a-517aaf4b9ffe" />
