### PR TITLE
[MARKUP] MenuSection 컴포넌트 퍼블리싱 #54

### DIFF
--- a/src/app/(with-nav)/courses/page.tsx
+++ b/src/app/(with-nav)/courses/page.tsx
@@ -1,7 +1,13 @@
+import MenuSection from "@/components/common/MenuSection";
+
 export default function Page() {
   return (
-    <h1 className="text-3xl font-bold">
-      코스 검색 페이지
-    </h1>
+    <div className="flex flex-col h-full px-5 pt-3 justify-start items-center gap-5">
+      <MenuSection title={"이달의 베스트 3 코스"}>
+        <div className="w-full h-40 bg-amber-300 flex justify-center items-center">
+          이달의 베스트 3코스 영역
+        </div>
+      </MenuSection>
+    </div>
   )
 }

--- a/src/components/common/MenuSection.tsx
+++ b/src/components/common/MenuSection.tsx
@@ -1,0 +1,13 @@
+interface MenuSectionProps {
+    title: string;
+    children: React.ReactNode;
+}
+
+export default function MenuSection({ title, children }: MenuSectionProps){
+    return(
+        <div className="w-full flex flex-col gap-1 justify-start items-start">
+            <span className="text-lg font-bold">{title}</span>
+            {children}
+        </div>
+    );
+}


### PR DESCRIPTION
## 📌 연관된 이슈

#54

## ✅ 작업 내용

MenuSection 컴포넌트를 퍼블리싱하여 메뉴 기본 틀을 생성하였습니다.


## 📷 스크린샷 (선택)
<img width="459" height="201" alt="스크린샷 2025-11-29 010833" src="https://github.com/user-attachments/assets/a4d5e0ca-7c7b-4fed-ac9c-108480359764" />

