### PR TITLE
[MARKUP] 코스 상세 조회 페이지 UI 퍼블리싱 #86

### DIFF
--- a/src/app/(with-header)/courses/[id]/page.tsx
+++ b/src/app/(with-header)/courses/[id]/page.tsx
@@ -1,7 +1,111 @@
+"use client"
+
+import CourseActionButtons from "@/components/common/CourseActionButtons";
+import HeaderLayout from "@/components/common/HeaderLayout";
+import coursePost from "@/mock/coursePost.json"
+import { useEffect, useState } from "react";
+import { CourseDetail } from "@/types/course";
+import LikeIcon from "@/components/common/LikeIcon";
+import Tag from "@/components/common/Tag";
+import CourseInfoSummary from "@/components/course/CourseInfoSummary";
+import KakaoMap from "@/components/map/KakaoMap";
+import PrimaryButton from "@/components/common/PrimaryButton";
+import { useRouter } from "next/navigation";
+import Modal from "@/components/common/Modal";
+import CourseMemoModal from "@/components/course/modal/CourseMemoModal";
+import CourseSection from "@/components/course/CourseSection";
+
 export default function Page() {
+  const router = useRouter();
+
+  const [courseData, setCourseData] = useState<CourseDetail>(coursePost as CourseDetail);
+  const [memoActiveList, setMemoActiveList] = useState<boolean[]>(
+    Array(courseData.steps.length).fill(false)
+  );
+  const [showCourseMemoModal, setShowCourseMemoModal] = useState(false);
+
+  const toggleMemoActive = (index: number) => {
+    setMemoActiveList(prev =>
+      prev.map((v, i) => (i === index ? !v : v))
+    );
+  };
+
+  // useEffect(() => {
+  //   // API.get("/course/2")
+  //   setCourseData(coursePost as CourseDetail);
+  // }, []);
+
   return (
-    <h1 className="text-3xl font-bold">
-      코스 상세 페이지
-    </h1>
+    <HeaderLayout title={""}>
+      <div className="flex flex-col h-full px-10 pb-5 justify-start gap-2">
+        {/* 수정 및 삭제 버튼 영역 */}
+        <div className="flex justify-end gap-3 items-center">
+          <CourseActionButtons type={"edit"} />
+          <CourseActionButtons type={"delete"} />
+        </div>
+
+        {/* 코스 타이틀 및 좋아요 버튼 영역 */}
+        <div className="w-full flex justify-between items-center">
+          <h1 className="text-xl font-bold">{courseData.title}</h1>
+          <LikeIcon liked={courseData.liked} count={courseData.likeNum} />
+        </div>
+
+        {/* 태그 영역 */}
+        <div className="flex gap-1.5 w-full">
+          {courseData.tag.map((item, index) => (
+            <Tag key={index} label={item} />
+          ))}
+        </div>
+
+        {/* 코스 정보 영역 */}
+        <div className="flex flex-col gap-0.5 w-full">
+          <CourseInfoSummary label={"작성자"} info={courseData.writer} />
+          <CourseInfoSummary label={"소요시간"} info={courseData.duration} />
+          <CourseInfoSummary label={"소요금액"} info={courseData.cost} />
+        </div>
+
+        {/* 코스 소개 내용 영역 */}
+        <div className="w-full">
+          <p className="text-sm text- font-semibold whitespace-pre-wrap leading-5 my-2">
+            {courseData.comment}
+          </p>
+        </div>
+
+        {/* 지도 영역 */}
+        <div className="w-full h-60">
+          <KakaoMap />
+        </div>
+
+        {/* 코스 영역 */}
+        <div className="flex flex-col w-full gap-2 my-2">
+          {courseData.steps.map((step, index) => (
+            <CourseSection
+              key={step.stepId}
+              stepOrder={step.stepOrder}
+              name={step.name}
+              memoActive={memoActiveList[index]}
+              onClick={() => toggleMemoActive(index)}
+            />
+          ))}
+        </div>
+
+        {/* 코스 시작하기 버튼 */}
+        <PrimaryButton
+          onClick={() => setShowCourseMemoModal(true)}
+          label={"코스 시작하기"}
+        />
+      </div>
+
+      {showCourseMemoModal && (
+        <Modal
+          title="장소별 메모 작성"
+          buttonLabel="코스 시작하기"
+          onClose={() => setShowCourseMemoModal(false)}
+          buttonClick={() => router.push("/map")}
+        >
+          <CourseMemoModal courseSteps={courseData.steps} />
+        </Modal>
+      )}
+    </HeaderLayout>
   )
 }

--- a/src/components/common/CourseActionButtons.tsx
+++ b/src/components/common/CourseActionButtons.tsx
@@ -1,0 +1,24 @@
+import { Pencil, Trash2 } from "lucide-react";
+
+interface CourseActionButtonsProps {
+    type: "edit" | "delete";
+    onClick?: () => void;
+}
+
+export default function CourseActionButtons({ type, onClick }: CourseActionButtonsProps) {
+
+    const isEdit = type === "edit";
+
+    const Icon = isEdit ? Pencil : Trash2;
+    const label = isEdit ? "수정" : "삭제";
+
+    return (
+        <button
+            onClick={onClick}
+            className="flex flex-col items-center"
+        >
+            <Icon size={22} color="#989898" />
+            <span className="text-[11px] text-[#989898]">{label}</span>
+        </button>
+    );
+}

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -6,15 +6,16 @@ interface ModalProps {
     title: string;
     children: React.ReactNode;
     buttonLabel: string;
+    buttonClick?: () => void;
 }
 
-export default function Modal({ onClose, title, children, buttonLabel }: ModalProps) {
+export default function Modal({ onClose, title, children, buttonLabel, buttonClick }: ModalProps) {
     return (
         <div
             className="w-full fixed inset-0 bg-black/50 flex justify-center items-center z-20"
         >
             <div
-                className="w-4/5 max-w-sm bg-white p-5 rounded-2xl flex flex-col items-center gap-5"
+                className="w-4/5 max-w-sm max-h-5/6 bg-white p-5 rounded-2xl flex flex-col items-center gap-5"
                 onClick={(e) => e.stopPropagation()}
             >
                 <div className="flex flex-col w-full">
@@ -31,11 +32,13 @@ export default function Modal({ onClose, title, children, buttonLabel }: ModalPr
                 </div>
 
                 {/* 모달 내부 콘텐츠 */}
-                <div className="w-full">{children}</div>
+                <div className="w-full flex-1 min-h-0 overflow-y-auto">
+                    {children}
+                </div>
 
                 {/* 모달 버튼 */}
                 <PrimaryButton
-                    onClick={onClose}
+                    onClick={buttonClick}
                     label={buttonLabel}
                 />
             </div>

--- a/src/components/common/PrimaryButton.tsx
+++ b/src/components/common/PrimaryButton.tsx
@@ -1,5 +1,5 @@
 interface PrimaryButtonProps {
-    onClick: () => void;
+    onClick?: () => void;
     label: string;
 }
 

--- a/src/components/course/CourseInfoSummary.tsx
+++ b/src/components/course/CourseInfoSummary.tsx
@@ -1,0 +1,14 @@
+interface CourseInfoSummaryProps{
+    label: "작성자"|"소요시간"|"소요금액";
+    info: string;
+}
+
+export default function CourseInfoSummary({ label, info }: CourseInfoSummaryProps){
+    return(
+        <div className="flex gap-1 text-[11px] text-[#8D8D8D] font-semibold">
+            <span>{label}</span>
+            |
+            <span>{info}</span>
+        </div>
+    );
+}

--- a/src/components/course/CourseLocationItem.tsx
+++ b/src/components/course/CourseLocationItem.tsx
@@ -4,7 +4,7 @@ import CourseLocationMemo from "./CourseLocationMemo";
 interface CourseLocationItemProps {
     stepOrder: number;
     name: string;
-    memoActive: boolean;
+    memoActive?: boolean;
     onClick?: () => void;
 }
 
@@ -28,12 +28,6 @@ export default function CourseLocationItem({ stepOrder, name, memoActive, onClic
                     : <ChevronRight size={25} color="#828282" strokeWidth={1} />
                 }
             </button>
-            
-            {memoActive && (
-                <CourseLocationMemo
-                    locationMemo={"춥거나 더울때는 소마미술관으로 대피🚨"}
-                />
-            )}
         </div>
     );
 }

--- a/src/components/course/CourseSection.tsx
+++ b/src/components/course/CourseSection.tsx
@@ -1,0 +1,27 @@
+import CourseLocationItem from "./CourseLocationItem";
+import CourseLocationMemo from "./CourseLocationMemo";
+
+interface CourseSectionProps {
+    stepOrder: number;
+    name: string;
+    memoActive?: boolean;
+    onClick?: () => void;
+}
+
+export default function CourseSection({ stepOrder, name, memoActive, onClick }: CourseSectionProps) {
+    return (
+        <div className="flex flex-col w-full gap-1">
+            <CourseLocationItem
+                stepOrder={stepOrder}
+                name={name}
+                memoActive={memoActive}
+                onClick={onClick}
+            />
+            {memoActive && (
+                <CourseLocationMemo
+                    locationMemo={"춥거나 더울때는 소마미술관으로 대피🚨"}
+                />
+            )}
+        </div>
+    );
+}

--- a/src/components/course/modal/CourseMemoModal.tsx
+++ b/src/components/course/modal/CourseMemoModal.tsx
@@ -1,0 +1,59 @@
+"use client"
+
+import { useRef, useState } from "react";
+import CourseLocationItem from "../CourseLocationItem";
+import { Step } from "@/types/course";
+
+interface CourseMemoModalProps {
+    courseSteps: Step[];
+}
+
+export default function CourseMemoModal({ courseSteps }: CourseMemoModalProps) {
+    const [memoActiveList, setMemoActiveList] = useState<boolean[]>(
+        Array(courseSteps.length).fill(false)
+    );
+
+    const toggleMemoActive = (index: number) => {
+        setMemoActiveList(prev =>
+            prev.map((v, i) => (i === index ? !v : v))
+        );
+    };
+
+    const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+    // textarea 자동 높이 조절
+    const handleResizeHeight = () => {
+        const textarea = textareaRef.current;
+        if (!textarea) return;
+
+        textarea.style.height = "auto";
+        textarea.style.height = textarea.scrollHeight + "px";
+    };
+
+    return (
+        <div className="flex flex-col w-full gap-2 overflow-y-auto">
+            {courseSteps.map((step, index) => (
+                <div className="flex flex-col w-full gap-1">
+                    <CourseLocationItem
+                        key={step.stepId}
+                        stepOrder={step.stepOrder}
+                        name={step.name}
+                        memoActive={memoActiveList[index]}
+                        onClick={() => toggleMemoActive(index)}
+                    />
+                    {
+                        memoActiveList[index] && (
+                            <textarea
+                                ref={textareaRef}
+                                onInput={handleResizeHeight}
+                                rows={1}
+                                className="rounded-xl p-3 gap-2 text-gray-700 whitespace-pre-line leading-relaxed w-full bg-[#F7F7F7] focus:outline-none text-sm font-medium placeholder:text-gray-300 placeholder:font-medium resize-none"
+                                placeholder="메모를 입력하세요"
+                            />
+                        )
+                    }
+                </div>
+            ))}
+        </div>
+    );
+}

--- a/src/mock/coursePost.json
+++ b/src/mock/coursePost.json
@@ -1,0 +1,78 @@
+{
+    "courseId": 2,
+    "title": "한성백제역 근처를 듀벅뜌벅",
+    "writer": "나는 아름다운 나비",
+    "secret": false,
+    "tag": [
+        "혼자",
+        "추움",
+        "뚜벅이"
+    ],
+    "comment": "한성백제역 근처에는... 어쩌구\r\n화장실 근처에 고양이가 살아욤 😺\r\n어쩌구 그래서 좋았어요..",
+
+    "steps": [
+        {
+            "stepId": 1,
+            "stepOrder": 1,
+            "name": "세계평화의문",
+            "latitude": 12.809,
+            "longitude": 123.123,
+            "description": "세계평화의문 근처에 포메인 맛집임👍🏻",
+            "photos": [
+                {
+                    "path": "",
+                    "isRep": true
+                }
+            ]
+        },
+        {
+            "stepId": 2,
+            "stepOrder": 2,
+            "name": "포메인",
+            "latitude": 22.032,
+            "longitude": 127.132,
+            "description": null,
+            "photos": []
+        },
+        {
+            "stepId": 3,
+            "stepOrder": 3,
+            "name": "수변무대",
+            "latitude": 24.032,
+            "longitude": 129.132,
+            "description": "음쏘굿",
+            "photos": []
+        },
+        {
+            "stepId": 4,
+            "stepOrder": 4,
+            "name": "소마미술관",
+            "latitude": 32.032,
+            "longitude": 129.132,
+            "description": "춥거나 더울때는 소마미술관으로 대피🚨",
+            "photos": [
+                {
+                    "path": "",
+                    "isRep": false
+                },
+                {
+                    "path": "",
+                    "isRep": false
+                }
+            ]
+        },
+        {
+            "stepId": 5,
+            "stepOrder": 5,
+            "name": "한성백제박물관",
+            "latitude": 29.032,
+            "longitude": 132.132,
+            "description": null,
+            "photos": []
+        }
+    ],
+    "duration": "MIN_0_30",
+    "cost": "WON_50000_60000",
+    "liked": false,
+    "likeNum": 3
+}

--- a/src/types/course.ts
+++ b/src/types/course.ts
@@ -1,6 +1,8 @@
+// types/course.ts
+
 export interface Course {
   courseId: number;
-  thumbnail: string;
+  thumbnail?: string;
   title: string;
   writer: string;
   likeNum: number;
@@ -13,3 +15,48 @@ export interface CourseListResponse {
   nextCursor: number;
   isLast: boolean;
 }
+
+export interface Photo {
+  path: string;
+  isRep: boolean;
+}
+
+export interface Step {
+  stepId: number;
+  stepOrder: number;
+  name: string;
+}
+
+export interface StepDetail extends Step {
+  latitude: number;
+  longitude: number;
+  description: string | null;
+  photos: Photo[];
+}
+
+// 기존 Course 타입을 확장해서 상세 타입 생성
+export interface CourseDetail extends Course {
+  secret: boolean;
+  tag: string[];
+  comment: string;
+  steps: Step[];
+  duration: string;
+  cost: string;
+}
+
+// export enum DurationEnum {
+//   MIN_0_30 = "MIN_0_30",
+//   MIN_30_60 = "MIN_30_60",
+//   MIN_60_120 = "MIN_60_120",
+//   MIN_120_PLUS = "MIN_120_PLUS",
+// }
+
+// export enum CostEnum {
+//   WON_0_10000 = "WON_0_10000",
+//   WON_10000_20000 = "WON_10000_20000",
+//   WON_20000_30000 = "WON_20000_30000",
+//   WON_30000_40000 = "WON_30000_40000",
+//   WON_40000_50000 = "WON_40000_50000",
+//   WON_50000_60000 = "WON_50000_60000",
+//   WON_60000_PLUS = "WON_60000_PLUS",
+// }


### PR DESCRIPTION
## 📌 연관된 이슈

#86

## ✅ 작업 내용

- 코스 상세 조회 페이지의 UI를 퍼블리싱하였습니다.
- CourseActionButtons 컴포넌트를 만들어 수정 및 삭제 버튼 영역을 구성하였습니다.
- Tag 컴포넌트를 통해 태그 영역을 구성하였습니다.
- CourseInfoSummary 컴포넌트를 만들어 코스 게시물의 정보 영역을 구성하였습니다.
- 코스 소개 내용 영역에서 `whitespace-pre-wrap` 속성을 추가하여 줄바꿈을 인식하도록 하였습니다.
- KakaoMap 컴포넌트를 통해 지도 영역을 구성하였습니다.
- CourseSection 컴포넌트를 만들어 CourseLocationItem컴포넌트만 따로 사용할 수 있도록 구성하였습니다.
- `코스 시작하기` 버튼 클릭 시 CourseMemoModal이 뜨도록 구현하였습니다.
- CourseMemoModal 컴포넌트를 만들어 코스 장소별 메모를 할 수 있도록 구현하였습니다.

## 📷 스크린샷 (선택)

<img width="496" height="896" alt="스크린샷 2025-12-02 131211" src="https://github.com/user-attachments/assets/e519d9fe-aa76-41f8-a64a-b528736fd2ed" />
<img width="415" height="597" alt="스크린샷 2025-12-02 152601" src="https://github.com/user-attachments/assets/314bcb59-311c-4b82-933f-fbde3d01ffd3" />
