### PR TITLE
[FEATURE] 로그인, 로그아웃 및 토큰 재발행 API 연동 #99

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "next": "15.5.6",
         "react": "19.1.0",
         "react-dom": "19.1.0",
-        "react-kakao-maps-sdk": "^1.2.0"
+        "react-kakao-maps-sdk": "^1.2.0",
+        "zustand": "^5.0.9"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -1279,7 +1280,7 @@
       "version": "19.2.7",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2245,7 +2246,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -5805,6 +5806,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.9.tgz",
+      "integrity": "sha512-ALBtUj0AfjJt3uNRQoL1tL2tMvj6Gp/6e39dnfT6uzpelGru8v1tPOGBzayOWbPJvujM8JojDk3E1LxeFisBNg==",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "next": "15.5.6",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-kakao-maps-sdk": "^1.2.0"
+    "react-kakao-maps-sdk": "^1.2.0",
+    "zustand": "^5.0.9"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,16 +1,47 @@
 // src/api/auth.ts
 import api from "@/libs/AxiosInstance"
 import { ApiResponse } from "@/types/api";
+import { SignupRequest, LoginRequest, LoginData } from "@/types/auth"
 
-export interface SignupRequest {
-  email: string;
-  nickname: string;
-  password: string;
-}
-
+// 회원가입 API
 export type SignupResponse = ApiResponse<null>;
 
 export async function signup(data: SignupRequest) {
   const res = await api.post<SignupResponse>("/api/users", data);
   return res.data;
+}
+
+// 로그인 API
+export type LoginResponse = ApiResponse<LoginData>;
+
+export async function login(data: LoginRequest): Promise<LoginResponse> {
+  const res = await api.post<LoginResponse>("/api/auth/login", data);
+  // 헤더에서 토큰 꺼내기
+  const accessToken = res.headers["authorization"];
+  const pureToken = accessToken.replace("Bearer ", "").trim();
+
+  if (accessToken && typeof window !== "undefined") {
+    localStorage.setItem("accessToken", pureToken);
+  }
+
+  return res.data;
+}
+
+// 로그아웃 API
+export type LogoutResponse = ApiResponse<null>;
+
+export async function logout(): Promise<LogoutResponse> {
+  const res = await api.post<LogoutResponse>("/api/auth/logout");
+
+  // 서버에서 로그아웃 성공 응답을 받으면 클라이언트에서도 토큰 제거
+  if (typeof window !== "undefined") {
+    localStorage.removeItem("accessToken");
+  }
+
+  return res.data;
+}
+
+// 토큰 재발행 API
+export async function reissue() {
+  return api.post("/api/auth/reissue");
 }

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -1,13 +1,7 @@
 // src/api/user.ts
 import api from "@/libs/AxiosInstance"
 import { ApiResponse } from "@/types/api";
-
-export type CheckType = "email" | "nickname";
-
-export interface CheckDuplicateRequest {
-  type: CheckType;
-  content: string;
-}
+import { CheckDuplicateRequest } from "@/types/user"
 
 export type CheckDuplicateResponse = ApiResponse<null>;
 

--- a/src/app/(start-view)/page.tsx
+++ b/src/app/(start-view)/page.tsx
@@ -4,16 +4,36 @@ import AuthInput from "@/components/user/AuthInput"
 import PrimaryButton from "@/components/common/PrimaryButton"
 import LinkButton from "@/components/user/LinkButton";
 import { useState } from "react";
+import { useLogin } from "@/hooks/useLogin"
+import { useRouter } from 'next/navigation';
+import Modal from "@/components/common/Modal";
+import ModalText from "@/components/common/ModalText";
 
 export default function Page() {
+  const router = useRouter();
+
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [showErrorModal, setShowErrorModal] = useState(false);
 
-  function handleSubmit(e?: React.FormEvent) {
+  const { mutate: loginMutate, isPending, error } = useLogin();
+
+  function handleLogin(e?: React.FormEvent) {
     if (e) e.preventDefault();
 
-    // 실제 로그인 요청 처리
-    console.log("로그인 요청:", { email, password });
+    loginMutate(
+      { email, password },
+      {
+        onSuccess: (res) => {
+          console.log("로그인 성공", res);
+          router.push("/home");
+        },
+        onError: () => {
+          console.log("로그인 실패");
+          setShowErrorModal(true);
+        },
+      }
+    );
   }
 
   return (
@@ -22,7 +42,7 @@ export default function Page() {
         안녕하세요!
       </h1>
 
-      <form onSubmit={handleSubmit} className="flex flex-col gap-6">
+      <form onSubmit={handleLogin} className="flex flex-col gap-6">
         <div className="flex flex-col">
           <AuthInput
             label="이메일"
@@ -41,17 +61,30 @@ export default function Page() {
         </div>
 
         <div className="flex justify-evenly">
-          <LinkButton href="/guest_laguage_select" label="비회원으로 즐기기" />
+          {/* <LinkButton href="/guest_laguage_select" label="비회원으로 즐기기" /> */}
+          <LinkButton href="/home" label="비회원으로 즐기기" />
           <LinkButton href="/signup" label="아직 회원이 아니신가요?" />
         </div>
 
         <div className="flex justify-center mt-2">
           <PrimaryButton
             label="로그인"
-            onClick={handleSubmit}
+            onClick={handleLogin}
           />
         </div>
       </form>
+
+      {/* 로그인 실패 시 모달 표시 */}
+            {showErrorModal && (
+              <Modal
+                title="로그인 실패"
+                buttonLabel="확인"
+                onClose={() => setShowErrorModal(false)}
+                buttonClick={() => setShowErrorModal(false)}
+              >
+                <ModalText text={"로그인 정보를 다시 확인해주세요."} />
+              </Modal>
+            )}
     </div>
   )
 }

--- a/src/app/(with-nav)/user/page.tsx
+++ b/src/app/(with-nav)/user/page.tsx
@@ -11,6 +11,7 @@ import AccountDeleteModal from "@/components/user/modal/AccountDeleteModal";
 import LogoutConfirmModal from "@/components/user/modal/LogoutConfirmModal";
 import AccountEditModal from "@/components/user/modal/AccountEditModal";
 import UserCourseButton from "@/components/user/UserCourseButtom";
+import { useLogout } from "@/hooks/useLogout";
 
 export default function Page() {
   const router = useRouter();
@@ -18,6 +19,16 @@ export default function Page() {
   const [showAccountDeleteModal, setShowAccountDeleteModal] = useState(false);
   const [showLogoutConfirmModal, setShowLogoutConfirmModal] = useState(false);
   const [showAccountEditModal, setShowAccountEditModal] = useState(false);
+
+  const { mutate: logoutMutate } = useLogout();
+
+  function handleLogout() {
+    logoutMutate(undefined, {
+      onSuccess: () => {
+        router.push("/");
+      },
+    });
+  }
 
   return (
     <div className="flex flex-col h-full px-10 py-6 justify-center items-center gap-5">
@@ -100,6 +111,7 @@ export default function Page() {
           title="로그아웃"
           buttonLabel="로그아웃"
           onClose={() => setShowLogoutConfirmModal(false)}
+          buttonClick={handleLogout}
         >
           <LogoutConfirmModal />
         </Modal>

--- a/src/hooks/useAuthInputValidation.ts
+++ b/src/hooks/useAuthInputValidation.ts
@@ -1,4 +1,5 @@
-import { checkDuplicate, CheckDuplicateRequest } from "@/api/user";
+import { checkDuplicate } from "@/api/user";
+import { CheckDuplicateRequest } from "@/types/user"
 import { useMutation } from "@tanstack/react-query";
 import { useState } from "react";
 

--- a/src/hooks/useCheckDuplicate.ts
+++ b/src/hooks/useCheckDuplicate.ts
@@ -1,5 +1,6 @@
 import { useMutation } from "@tanstack/react-query";
-import { checkDuplicate, CheckDuplicateRequest } from "@/api/user";
+import { checkDuplicate } from "@/api/user";
+import { CheckDuplicateRequest } from "@/types/user"
 
 export function useCheckDuplicate() {
   return useMutation({

--- a/src/hooks/useLogin.ts
+++ b/src/hooks/useLogin.ts
@@ -1,0 +1,19 @@
+import { useMutation } from "@tanstack/react-query";
+import { login } from "@/api/auth";
+import { LoginRequest } from "@/types/auth"
+import { useUserStore } from "@/store/userStore";
+
+export function useLogin() {
+    const setUser = useUserStore((state) => state.setUser);
+
+    return useMutation({
+        mutationFn: (payload: LoginRequest) => login(payload),
+
+        onSuccess: (res) => {
+            if (res.data) {
+                // ← Zustand에 저장
+                setUser(res.data);
+            }
+        },
+    });
+}

--- a/src/hooks/useLogout.ts
+++ b/src/hooks/useLogout.ts
@@ -1,0 +1,19 @@
+// src/hooks/useLogout.ts
+import { useMutation } from "@tanstack/react-query";
+import { logout } from "@/api/auth";
+import { useUserStore } from "@/store/userStore";
+
+export function useLogout() {
+  const clearUser = useUserStore((state) => state.clearUser);
+
+  return useMutation({
+    mutationFn: () => logout(),
+    onSuccess: () => {
+      // Zustand에서 유저 정보 초기화
+      clearUser();
+    },
+    onError: (err) => {
+      console.error("로그아웃 실패:", err);
+    },
+  });
+}

--- a/src/hooks/useSignup.ts
+++ b/src/hooks/useSignup.ts
@@ -1,5 +1,6 @@
 import { useMutation } from "@tanstack/react-query";
-import { signup, SignupRequest } from "@/api/auth";
+import { signup } from "@/api/auth";
+import { SignupRequest } from "@/types/auth"
 
 export function useSignup() {
   return useMutation({

--- a/src/libs/AxiosInstance.ts
+++ b/src/libs/AxiosInstance.ts
@@ -1,31 +1,56 @@
 import axios from "axios";
 
 const api = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_API_BASE_URL,
+    baseURL: process.env.NEXT_PUBLIC_API_BASE_URL,
+    withCredentials: true,
 });
 
 // 요청 인터셉터
 api.interceptors.request.use(
-  (config) => {
-    // 요청 보내기 직전에 실행됨
-    return config;
-  },
-  (error) => {
-    // 요청 설정 중 에러
-    return Promise.reject(error);
-  }
+    (config) => {
+        // 요청 보내기 직전에 실행됨
+        if (typeof window !== "undefined") {
+            const token = localStorage.getItem("accessToken");
+            if (token && config.headers) {
+                config.headers.Authorization = `Bearer ${token}`
+            }
+        }
+        return config;
+    },
+    (error) => {
+        // 요청 설정 중 에러
+        return Promise.reject(error);
+    }
 );
 
 // 응답 인터셉터
 api.interceptors.response.use(
-  (response) => {
-    // 응답(200~299) 도착 시 실행
-    return response;
-  },
-  (error) => {
-    // 에러 응답(4xx, 5xx) 도착 시 실행
-    return Promise.reject(error);
-  }
+    (response) => response,
+    async (error) => {
+        const originalRequest = error.config;
+
+        if (error.response?.status === 401 && !originalRequest._retry) {
+            originalRequest._retry = true;
+            try {
+                const res = await api.post("/api/auth/reissue");
+
+                const newAccessToken = res.headers["authorization"];
+
+                if (newAccessToken) {
+                    localStorage.setItem("accessToken", newAccessToken);
+                }
+
+                originalRequest.headers.Authorization = newAccessToken;
+
+                return api(originalRequest);
+            } catch (refreshError) {
+                console.error("리프레시 토큰 만료됨 → 로그아웃 처리 필요");
+                localStorage.removeItem("accessToken");
+                return Promise.reject(refreshError);
+            }
+        }
+        return Promise.reject(error);
+    }
 );
 
 export default api;

--- a/src/store/userStore.ts
+++ b/src/store/userStore.ts
@@ -1,0 +1,37 @@
+// src/store/userStore.ts : 회원정보 저장 store
+import { create } from "zustand";
+import type { LoginData } from "@/types/auth";
+
+interface UserState {
+  userId: number | null;
+  email: string | null;
+  nickname: string | null;
+
+  isLoggedIn: boolean;
+
+  setUser: (data: LoginData) => void;
+  clearUser: () => void;
+}
+
+export const useUserStore = create<UserState>((set) => ({
+  userId: null,
+  email: null,
+  nickname: null,
+  isLoggedIn: false,
+
+  setUser: (data) =>
+    set({
+      userId: data.userId,
+      email: data.email,
+      nickname: data.nickname,
+      isLoggedIn: true,
+    }),
+
+  clearUser: () =>
+    set({
+      userId: null,
+      email: null,
+      nickname: null,
+      isLoggedIn: false,
+    }),
+}));

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,0 +1,21 @@
+// types/auth.ts
+
+// 회원가입 요청 타입
+export interface SignupRequest {
+  email: string;
+  nickname: string;
+  password: string;
+}
+
+// 로그인 요청 타입
+export interface LoginRequest {
+  email: string;
+  password: string;
+}
+
+// 로그인 시 응답으로 오는 data 타입
+export interface LoginData {
+  userId: number;
+  email: string;
+  nickname: string;
+}

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,0 +1,10 @@
+// types/auth.ts
+
+// 중복 체크 type의 타입
+export type CheckType = "email" | "nickname";
+
+// 중복 체크 API 요청 타입 
+export interface CheckDuplicateRequest {
+  type: CheckType;
+  content: string;
+}


### PR DESCRIPTION
## 📌 연관된 이슈

#99

## ✅ 작업 내용

로그인 API를 연동하였습니다.
로그아웃 API를 연동하였습니다.
토큰 재발행 API를 연동하였습니다.
src/libs/AxiosInstance.ts 파일의 요청 및 응답 인터셉터를 통해 자동으로 헤더에 토큰 붙이기 및 토큰재발행 로직을 구현하였습니다.


## 🖇️ 참고

`withCredentials: true` 속성을 추가하지 않아서 쿠기를 저장하지 못해 401 에러가 발생하였음.
추가 이후 정상적으로 200코드가 오고 있음 😵‍💫🥹