### PR TITLE
[BUG] 소요시간 및 소요금액 데이터 없을 시 NONE이라고 출력되는 현상 #133

### DIFF
--- a/src/app/(with-header)/courses/[id]/page.tsx
+++ b/src/app/(with-header)/courses/[id]/page.tsx
@@ -165,15 +165,21 @@ export default function Page() {
         {/* 코스 정보 영역 */}
         <div className="flex flex-col gap-0.5 w-full">
           <CourseInfoSummary label={"작성자"} info={courseData.writer} />
-          <CourseInfoSummary
-            label={"소요시간"}
-            info={getDurationLabel(courseData.duration)}
-          />
+          {/* 소요시간: NONE 아닐 때만 */}
+          {courseData.duration !== "NONE" && (
+            <CourseInfoSummary
+              label={"소요시간"}
+              info={getDurationLabel(courseData.duration)}
+            />
+          )}
 
-          <CourseInfoSummary
-            label={"소요금액"}
-            info={getCostLabel(courseData.cost)}
-          />
+          {/* 소요금액: NONE 아닐 때만 */}
+          {courseData.cost !== "NONE" && (
+            <CourseInfoSummary
+              label={"소요금액"}
+              info={getCostLabel(courseData.cost)}
+            />
+          )}
         </div>
 
         {/* 코스 소개 내용 영역 */}


### PR DESCRIPTION
## 📌 연관된 이슈

#133

## ✅ 작업 내용

코스 게시글 페이지에서 소요 시간 및 소요 금액이 NONE이 아닐 경우에만 출력이 되도록 처리하였습니다.


## 📷 스크린샷 (선택)

<img width="370" height="513" alt="스크린샷 2025-12-17 192446" src="https://github.com/user-attachments/assets/68dec941-acbf-4c6f-afa6-86bb5b26892e" />
