### PR TITLE
[BUG] 작성 글 리스트 페이지 및 좋아요한 게시글 페이지 내에서 좋아요 클릭이 안되는 현상 #134

### DIFF
--- a/src/components/common/LikeIcon.tsx
+++ b/src/components/common/LikeIcon.tsx
@@ -1,15 +1,21 @@
 import { Heart } from "lucide-react";
 
 interface LikeIconProps {
-    liked: boolean; 
+    liked: boolean;
     count: number;
     onClick?: () => void;
 }
 
-export default function LikeIcon({ liked, count, onClick }: LikeIconProps){
-    return(
+export default function LikeIcon({ liked, count, onClick }: LikeIconProps) {
+    return (
         <div className="flex flex-col items-center">
-            <button onClick={onClick}>
+            <button
+                onClick={(e) => {
+                    e.preventDefault();   // Link 이동 막기
+                    e.stopPropagation();  // 상위로 이벤트 전파 차단
+                    onClick?.();
+                }}
+            >
                 <Heart
                     className="w-5 h-5"
                     fill={liked ? "#FF5252" : "none"}

--- a/src/components/user/UserCourseList.tsx
+++ b/src/components/user/UserCourseList.tsx
@@ -3,6 +3,7 @@ import Image from "next/image";
 import Tag from "../common/Tag";
 import Link from "next/link";
 import { Tags } from "@/constants/tags";
+import { useLike } from "@/hooks/course/useLike";
 
 interface UserCourseListProps {
     courseId: number;
@@ -15,9 +16,7 @@ interface UserCourseListProps {
 }
 
 export default function UserCourseList({ courseId, thumbnail, title, writer, tags, liked, likeNum }: UserCourseListProps) {
-
-    // const displayThumbnail =
-    //     thumbnail && thumbnail.trim() !== "" ? thumbnail : "/img/OlCo_logo_3.png";
+    const { useLiked, useLikeNum, toggle } = useLike(courseId, liked, likeNum);
 
     const CLOUD_FRONT = "https://dpv9t0vlhs3c7.cloudfront.net/";
 
@@ -62,7 +61,7 @@ export default function UserCourseList({ courseId, thumbnail, title, writer, tag
 
                 {/* 좋아요 영역 */}
                 <div className="flex justify-end">
-                    <LikeIcon liked={liked} count={likeNum} />
+                    <LikeIcon liked={useLiked} count={useLikeNum} onClick={toggle} />
                 </div>
             </div>
         </Link>


### PR DESCRIPTION
## 📌 연관된 이슈

#134

## ✅ 작업 내용

`const { useLiked, useLikeNum, toggle } = useLike(courseId, liked, likeNum);`를 통해 좋아요 버튼 클릭 시 이벤트를 처리하였습니다.
추가적으로 좋아요 버튼 클릭 시 상위 컴포넌트의 Link 속성으로 인해 경로이동이 되어 
`e.preventDefault();` 와 `e.stopPropagation();`로 이동이 되지 않도록 처리하였습니다.
